### PR TITLE
Exporting the test failure reason in VDTESTING_FAILURE_REASON

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | Environment Variable | Description |
 | --- | --- |
 | `VDTESTING_DOWNLOADED_FILES_DIR` | The directory containing the downloaded files if you have set `directories_to_pull` and `download_test_results` inputs above. |
+| `VDTESTING_FAILURE_REASON` | A string containing the outcome and if the test failed. This can be any of these possible values: Crashed, NotInstalled, OtherNativeCrash, TimedOut, UnableToCrawl. Default value None if unable to triage the failure result. |
 </details>
 
 ## 🙋 Contributing

--- a/main.go
+++ b/main.go
@@ -149,23 +149,31 @@ func main() {
 						outcome = colorstring.Green(outcome)
 					case "failure":
 						successful = false
+						failureReason := "None"
+
 						if step.Outcome.FailureDetail != nil {
 							if step.Outcome.FailureDetail.Crashed {
-								outcome += "(Crashed)"
+								failureReason = "Crashed"
 							}
 							if step.Outcome.FailureDetail.NotInstalled {
-								outcome += "(NotInstalled)"
+								failureReason = "NotInstalled"
 							}
 							if step.Outcome.FailureDetail.OtherNativeCrash {
-								outcome += "(OtherNativeCrash)"
+								failureReason = "OtherNativeCrash"
 							}
 							if step.Outcome.FailureDetail.TimedOut {
-								outcome += "(TimedOut)"
+								failureReason = "TimedOut"
 							}
 							if step.Outcome.FailureDetail.UnableToCrawl {
-								outcome += "(UnableToCrawl)"
+								failureReason = "UnableToCrawl"
 							}
+							outcome += "(" + failureReason + ")"
 						}
+
+						if err := tools.ExportEnvironmentWithEnvman("VDTESTING_FAILURE_REASON", outcome); err != nil {
+							log.Warnf("Failed to export environment (VDTESTING_FAILURE_REASON), error: %s", err)
+						}
+
 						outcome = colorstring.Red(outcome)
 					case "inconclusive":
 						successful = false

--- a/step.yml
+++ b/step.yml
@@ -437,4 +437,9 @@ outputs:
     opts:
       title: "Downloaded files directory"
       description: "The directory containing the downloaded files if you have set `directories_to_pull` and `download_test_results` inputs above."
-      summary: "The directory containing the downloaded files if you have set `directories_to_pull` and `download_test_results` inputs above."
+      summary: "The directory containing the downloaded files if you have set `directories_to_pull` and `download_test_results` inputs above."  - VDTESTING_DOWNLOADED_FILES_DIR:
+  - VDTESTING_FAILURE_REASON:
+    opts:
+      title: "Failure reason for the UI tests"
+      description: "A string containing the outcome and if the test failed."
+      summary: "A string containing the outcome and if the test failed. This can be any of these possible values: Crashed, NotInstalled, OtherNativeCrash, TimedOut, UnableToCrawl. Default value None if unable to triage the failure result."


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

This PR changes the step to export `VDTESTING_FAILURE_REASON` when the UI test fails. This allows the developers to use the environment variable to utilise the failure reason in the next steps. e.g. They can put the failure reason in the slack messages to identify failure the reasons easily.

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

Updated `main.go` to export `VDTESTING_FAILURE_REASON` using envman with the failure reason (which is the same as what we display in the outcome summary.)

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

No alternative solutions were considered.

### Decisions

<!-- Please list decisions that were made for this change. -->
