### PR TITLE
Add support for uniform sharding on instrumentation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | `inst_test_runner_class` | The fully-qualified Java class name of the instrumentation test runner (leave empty to use the last name extracted from the APK manifest). |  |  |
 | `inst_test_targets` | A list of one or more instrumentation test targets to be run (default: all targets). Each target must be fully qualified with the package name or class name, in one of these formats: - `package package_name` - `class package_name.class_name` - `class package_name.class_name#method_name` For example: `class com.my.company.app.MyTargetClass,class com.my.company.app.MyOtherTargetClass`  |  |  |
 | `inst_use_orchestrator` | The option of whether running each test within its own invocation of instrumentation with Android Test Orchestrator or not.  | required | `false` |
+| `inst_num_uniform_shards` | The number of uniform shards across which to distribute test cases. The shards are run in parallel on separate devices, a value between 1 and 50. | | |
 | `robo_initial_activity` | The initial activity used to start the app during a robo test. (leave empty to get it extracted from the APK manifest) |  |  |
 | `robo_max_depth` | The maximum depth of the traversal stack a robo test can explore. Needs to be at least 2 to make Robo explore the app beyond the first activity(leave empty to use the default value: `50`)  |  |  |
 | `robo_max_steps` | The maximum number of steps/actions a robo test can execute(leave empty to use the default value: `no limit`).  |  |  |

--- a/config.go
+++ b/config.go
@@ -52,10 +52,11 @@ type ConfigsModel struct {
 	VerboseLog            bool `env:"use_verbose_log,opt[true,false]"`
 
 	// instrumentation
-	InstTestPackageID   string `env:"inst_test_package_id"`
-	InstTestRunnerClass string `env:"inst_test_runner_class"`
-	InstTestTargets     string `env:"inst_test_targets"`
-	UseOrchestrator     bool   `env:"inst_use_orchestrator,opt[true,false]"`
+	InstTestPackageID   	string `env:"inst_test_package_id"`
+	InstTestRunnerClass 	string `env:"inst_test_runner_class"`
+	InstTestTargets     	string `env:"inst_test_targets"`
+	UseOrchestrator     	bool   `env:"inst_use_orchestrator,opt[true,false]"`
+	NumberOfUniformShards 	int    `env:"inst_num_uniform_shards,range[0..50]"`
 
 	// robo
 	RoboInitialActivity string `env:"robo_initial_activity"`
@@ -113,6 +114,7 @@ func (configs *ConfigsModel) print() {
 		log.Printf("- InstTestRunnerClass: %s", configs.InstTestRunnerClass)
 		log.Printf("- InstTestTargets: %s", configs.InstTestTargets)
 		log.Printf("- UseOrchestrator: %t", configs.UseOrchestrator)
+		log.Printf("- NumberOfUniformShards: %d", configs.NumberOfUniformShards)
 	}
 
 	//robo

--- a/step.yml
+++ b/step.yml
@@ -1,5 +1,5 @@
-title: "Virtual Device Testing for Android"
-summary: Run Android UI tests on virtual devices
+title: "Virtual Device Testing for Android (Shard)"
+summary: Run Android UI tests on virtual devices (Shard)
 description: |-
   Run Android UI tests on virtual devices. This Step collects the built APK/AAB file from the `$BITRISE_APK_PATH` and in case of instrumentation tests, the `$BITRISE_TEST_APK_PATH` Environment Variables and uses Firebase Test Lab to run UI tests on them.
   
@@ -40,9 +40,9 @@ description: |-
   - [Android Build for UI Testing](https://www.bitrise.io/integrations/steps/android-build-for-ui-testing)
   - [Deploy to Bitrise.io](https://www.bitrise.io/integrations/steps/deploy-to-bitrise-io)
 
-website: https://github.com/bitrise-steplib/steps-virtual-device-testing-for-android
-source_code_url: https://github.com/bitrise-steplib/steps-virtual-device-testing-for-android
-support_url: https://github.com/bitrise-steplib/steps-virtual-device-testing-for-android/issues
+website: https://github.com/FrancescoRigoni/steps-virtual-device-testing-for-android
+source_code_url: https://github.com/FrancescoRigoni/steps-virtual-device-testing-for-android
+support_url: https://github.com/FrancescoRigoni/steps-virtual-device-testing-for-android/issues
 project_type_tags:
   - android
   - cordova
@@ -61,7 +61,7 @@ meta:
 
 toolkit:
   go:
-    package_name: github.com/bitrise-steplib/steps-virtual-device-testing-for-android
+    package_name: github.com/FrancescoRigoni/steps-virtual-device-testing-for-android
 inputs:
   - app_path: "$BITRISE_APK_PATH"
     opts:
@@ -202,6 +202,14 @@ inputs:
       value_options:
         - "false"
         - "true"
+  - inst_num_uniform_shards:
+    opts:
+      title: "Uniform shards number"
+      summary: |
+        The number of shards across which to distribute test cases. The shards are run in parallel on separate devices. 
+      description: |
+        A value between 1 and 50. For example, if your test execution contains 20 test cases and you specify four shards, the instrumentation command passes arguments of `-e numShards 4` to `AndroidJUnitRunner` and each shard executes about five test cases. Based on the sharding mechanism `AndroidJUnitRunner` uses, there is no guarantee that test cases will be distributed with perfect uniformity.     
+        If zero is specified then no uniform sharding is applied and all test cases run on a single device.
   - robo_initial_activity:
     opts:
       category: "Robo Test"

--- a/test_api.go
+++ b/test_api.go
@@ -208,6 +208,12 @@ func startTestRun(configs ConfigsModel, testAssets TestAssetsAndroid) error {
 		} else {
 			testModel.TestSpecification.AndroidInstrumentationTest.OrchestratorOption = "DO_NOT_USE_ORCHESTRATOR"
 		}
+
+		if int64(configs.NumberOfUniformShards) > 0 {
+			testModel.TestSpecification.AndroidInstrumentationTest.ShardingOption = &testing.ShardingOption{}
+			testModel.TestSpecification.AndroidInstrumentationTest.ShardingOption.UniformSharding = &testing.UniformSharding{}
+			testModel.TestSpecification.AndroidInstrumentationTest.ShardingOption.UniformSharding.NumShards = int64(configs.NumberOfUniformShards)
+		}
 		log.Debugf("AndroidInstrumentationTest: %+v", testModel.TestSpecification.AndroidInstrumentationTest)
 	case testTypeRobo:
 		testModel.TestSpecification.AndroidRoboTest = &testing.AndroidRoboTest{}


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

In order to speed up our builds we have to take advantage of uniform test sharding when running UI tests.
This step did not support it so I added it.

### Changes

- Add configuration options for uniform sharding
- Add the sharding configuration (if needed) when invoking firebase test lab
