### PR TITLE
Ignore maintenance tests during ci

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -16,6 +16,11 @@ workflows:
     - path::./:
         inputs:
           - test_type: instrumentation
+          - download_test_results: "true"
+    - deploy-to-bitrise-io@2:
+        inputs:
+        - is_compress: 'true'
+        - deploy_path: "$VDTESTING_DOWNLOADED_FILES_DIR"
 
   maintenance:
     steps:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -9,10 +9,14 @@ workflows:
     - go-list:
     - golint:
     - errcheck:
+    # Ignoring maintenance test as it needs gcloud binary
     - go-test:
+        inputs:
+        - packages: "."
     - path::./:
         inputs:
           - test_type: instrumentation
+
   maintenance:
     steps:
     - go-test:


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *NO* [version update](https://semver.org/)

### Context

This PR fixes the CI build (for example [this](https://github.com/bitrise-steplib/steps-virtual-device-testing-for-android/pull/92)) by ignoring the maintenance tests. Additionally, the CI build fetches test assets and deploys them, for debugabbility.
