### PR TITLE
Add warning for crash detection

### DIFF
--- a/main.go
+++ b/main.go
@@ -167,8 +167,7 @@ func main() {
 						dimensionToStatus[dimensionID] = isSuccess
 					}
 
-					failureDetail := step.Outcome.FailureDetail
-					if failureDetail != nil && failureDetail.Crashed {
+					if step.Outcome != nil && step.Outcome.FailureDetail != nil && step.Outcome.FailureDetail.Crashed {
 						crashed = true
 					}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

Firebase can detect crashes happening during the device run. If the crash happened in between test case execution then the Firebase build status will be failed but this failure will not appear in the test results as all of the test cases executed successfully. 

We will print a warning highlighting this.