### PR TITLE
[CI-6091] Strip parameter suffix from quarantined test names

### DIFF
--- a/config.go
+++ b/config.go
@@ -312,6 +312,7 @@ func parseQuarantinedTests(quarantinedTestsInput string) ([]string, error) {
 	}
 
 	var quarantinedTestsList []string
+	seen := map[string]struct{}{}
 	for _, qt := range quarantinedTests {
 		// JUnit parametrized tests carry a "[index: param]" suffix that Firebase's
 		// TestTarget API rejects; strip it so the whole method is excluded.
@@ -323,7 +324,12 @@ func parseQuarantinedTests(quarantinedTestsInput string) ([]string, error) {
 			continue
 		}
 
-		quarantinedTestsList = append(quarantinedTestsList, fmt.Sprintf("notClass %s#%s", qt.ClassName, testCaseName))
+		target := fmt.Sprintf("notClass %s#%s", qt.ClassName, testCaseName)
+		if _, ok := seen[target]; ok {
+			continue
+		}
+		seen[target] = struct{}{}
+		quarantinedTestsList = append(quarantinedTestsList, target)
 	}
 
 	return quarantinedTestsList, nil

--- a/config.go
+++ b/config.go
@@ -313,11 +313,17 @@ func parseQuarantinedTests(quarantinedTestsInput string) ([]string, error) {
 
 	var quarantinedTestsList []string
 	for _, qt := range quarantinedTests {
-		if qt.ClassName == "" || qt.TestCaseName == "" {
+		// JUnit parametrized tests carry a "[index: param]" suffix that Firebase's
+		// TestTarget API rejects; strip it so the whole method is excluded.
+		testCaseName := qt.TestCaseName
+		if i := strings.IndexByte(testCaseName, '['); i >= 0 {
+			testCaseName = strings.TrimSpace(testCaseName[:i])
+		}
+		if qt.ClassName == "" || testCaseName == "" {
 			continue
 		}
 
-		quarantinedTestsList = append(quarantinedTestsList, fmt.Sprintf("notClass %s#%s", qt.ClassName, qt.TestCaseName))
+		quarantinedTestsList = append(quarantinedTestsList, fmt.Sprintf("notClass %s#%s", qt.ClassName, testCaseName))
 	}
 
 	return quarantinedTestsList, nil

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseQuarantinedTests(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "empty input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "plain test name",
+			input: `[{"className":"pkg.Cls","testCaseName":"foo"}]`,
+			want:  []string{"notClass pkg.Cls#foo"},
+		},
+		{
+			name:  "JUnit indexed parameter suffix",
+			input: `[{"className":"pkg.Cls","testCaseName":"foo[0]"}]`,
+			want:  []string{"notClass pkg.Cls#foo"},
+		},
+		{
+			name:  "JUnit5 named parameter suffix (SSW-2961 reproducer)",
+			input: `[{"className":"com.syscocorp.mss.products.ProductDetailsFragmentTest","testCaseName":"test_show_product_specialOffer_banner_when_offer_available[1: TestData(unified=false)]"}]`,
+			want:  []string{"notClass com.syscocorp.mss.products.ProductDetailsFragmentTest#test_show_product_specialOffer_banner_when_offer_available"},
+		},
+		{
+			name:  "whitespace before parameter suffix",
+			input: `[{"className":"pkg.Cls","testCaseName":"foo [0]"}]`,
+			want:  []string{"notClass pkg.Cls#foo"},
+		},
+		{
+			name:  "empty test case name is skipped",
+			input: `[{"className":"pkg.Cls","testCaseName":""}]`,
+			want:  nil,
+		},
+		{
+			name:  "empty class name is skipped",
+			input: `[{"className":"","testCaseName":"foo"}]`,
+			want:  nil,
+		},
+		{
+			name:  "test case name reduces to empty after stripping is skipped",
+			input: `[{"className":"pkg.Cls","testCaseName":"[0]"}]`,
+			want:  nil,
+		},
+		{
+			name:  "multiple entries mix plain and parametrized",
+			input: `[{"className":"pkg.A","testCaseName":"foo"},{"className":"pkg.B","testCaseName":"bar[1: TestData(unified=false)]"}]`,
+			want: []string{
+				"notClass pkg.A#foo",
+				"notClass pkg.B#bar",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseQuarantinedTests(tc.input)
+			if err != nil {
+				t.Fatalf("parseQuarantinedTests() returned error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("parseQuarantinedTests() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseQuarantinedTests_InvalidJSON(t *testing.T) {
+	_, err := parseQuarantinedTests("not json")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -27,9 +27,9 @@ func TestParseQuarantinedTests(t *testing.T) {
 			want:  []string{"notClass pkg.Cls#foo"},
 		},
 		{
-			name:  "JUnit5 named parameter suffix (SSW-2961 reproducer)",
-			input: `[{"className":"com.syscocorp.mss.products.ProductDetailsFragmentTest","testCaseName":"test_show_product_specialOffer_banner_when_offer_available[1: TestData(unified=false)]"}]`,
-			want:  []string{"notClass com.syscocorp.mss.products.ProductDetailsFragmentTest#test_show_product_specialOffer_banner_when_offer_available"},
+			name:  "JUnit5 named parameter suffix",
+			input: `[{"className":"pkg.Cls","testCaseName":"foo[1: TestData(unified=false)]"}]`,
+			want:  []string{"notClass pkg.Cls#foo"},
 		},
 		{
 			name:  "whitespace before parameter suffix",
@@ -58,6 +58,16 @@ func TestParseQuarantinedTests(t *testing.T) {
 				"notClass pkg.A#foo",
 				"notClass pkg.B#bar",
 			},
+		},
+		{
+			name:  "duplicate parameter instances dedupe to one entry",
+			input: `[{"className":"pkg.Cls","testCaseName":"foo[0]"},{"className":"pkg.Cls","testCaseName":"foo[1: TestData(unified=false)]"}]`,
+			want:  []string{"notClass pkg.Cls#foo"},
+		},
+		{
+			name:  "duplicate plain entries dedupe to one entry",
+			input: `[{"className":"pkg.Cls","testCaseName":"foo"},{"className":"pkg.Cls","testCaseName":"foo"}]`,
+			want:  []string{"notClass pkg.Cls#foo"},
 		},
 	}
 


### PR DESCRIPTION
## Summary

JUnit parametrized tests carry a `[index: param]` suffix in their reported test case names (for example `foo[1: TestData(unified=false)]`). When such an entry shows up in the `quarantined_tests` input, the step formats it directly into a `notClass <className>#<testCaseName>` filter and Firebase Test Lab's `TestTarget` API rejects it with HTTP 400:

```
googleapi: Error 400: Field "TestTarget" with value
"notClass com.example.FooTest#bar[1: TestData(unified=false)]" is invalid
```

The build then fails at `Starting test run failed`, blocking the customer until they remove the quarantined entry.

This change strips the `[…]` suffix from `TestCaseName` before formatting the `notClass` filter, so the entire method (every parameter instance) is excluded — which is the desired behavior for a flaky parametrized test, and the only granularity Firebase supports here.

## Context

- Refs SWAT ticket SSW-2961 (Sysco Labs Android UI builds blocked).
- Builds on top of #114 (1.3.3), which fixed the related issue of quarantined targets overwriting `inst_test_targets`.
- Root cause discovered together with @kgodrei: `testquarantine.QuarantinedTest.TestCaseName` is consumed verbatim, but the value persisted by the Bitrise console UI for parametrized tests includes the JUnit run-identifier suffix that Firebase does not accept.

## Change

`config.go` — `parseQuarantinedTests()`:

```go
testCaseName := qt.TestCaseName
if i := strings.IndexByte(testCaseName, '['); i >= 0 {
    testCaseName = strings.TrimSpace(testCaseName[:i])
}
if qt.ClassName == "" || testCaseName == "" {
    continue
}
```

If the resulting `testCaseName` is empty (e.g. the input was just `[0]`), the entry is skipped instead of producing a malformed filter.

## Tests

New `config_test.go` covering `parseQuarantinedTests`:

- empty input
- plain test name → `notClass pkg.Cls#foo`
- JUnit indexed suffix `foo[0]`
- JUnit5 named parameter (the SSW-2961 reproducer): `foo[1: TestData(unified=false)]`
- whitespace before `[`: `foo [0]`
- empty `TestCaseName` skipped
- empty `ClassName` skipped
- `TestCaseName` reduces to empty after stripping (`[0]`) skipped
- multi-entry mix of plain and parametrized
- invalid JSON returns an error

`go fmt`, `go vet`, `go test ./...` all pass locally.

## Test plan

- [ ] CI green
- [ ] Smoke: re-run the Sysco repro pipeline with a parametrized test in `quarantined_tests` — expect the step log line `Test targets: [... notClass <Cls>#<method> ...]` (no `[…]` suffix), Firebase no longer returns HTTP 400, and every parameter instance of the quarantined test is excluded while the rest of the package filter is honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)